### PR TITLE
Remove non-existent $spacing variable .uds-hero-video wrapper

### DIFF
--- a/acf-block-templates/hero-video/hero-video.php
+++ b/acf-block-templates/hero-video/hero-video.php
@@ -79,7 +79,7 @@ $template       = array(
 );
 
 // Block output.
-echo '<div class="uds-hero-video ' . esc_html( $size ) . esc_html( $alignment ) . ' has-btn-row ' . esc_html( $additional_classes ) . '" style="' . $spacing . '">';
+echo '<div class="uds-hero-video ' . esc_html( $size ) . esc_html( $alignment ) . ' has-btn-row ' . esc_html( $additional_classes ) . '">';
 echo '<div class="hero-overlay"></div>';
 if ( $video ) {
 	?>


### PR DESCRIPTION
This missing variable was throwing a warning in the hero-video block:

`Warning: Undefined variable $spacing in /Users/joeydi/Sites/asulearningenterprise/wp-content/plugins/pitchfork-blocks/acf-block-templates/hero-video/hero-video.php on line 83`

![CleanShot 2024-06-28 at 10 48 01@2x](https://github.com/asuengineering/pitchfork-blocks/assets/173391/01b13bc0-0439-42c9-82fd-7f151e6410c3)